### PR TITLE
Align project data and gamification mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,51 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# EuroVision App
 
-## Getting Started
+Aplicação Next.js que centraliza iniciativas de inovação, métricas executivas e recursos de engajamento/gamificação.
 
-First, run the development server:
+## Pré-requisitos
+
+1. **Node.js 20+** – utilize o mesmo runtime usado pelo Next.js 15.
+2. **pnpm** – o projeto usa pnpm para gerenciar dependências (`corepack enable pnpm`).
+
+## Configuração de variáveis de ambiente
+
+Crie um arquivo `.env.local` na raiz do projeto com as variáveis abaixo:
+
+| Variável | Obrigatória | Descrição |
+| --- | --- | --- |
+| `NEXT_PUBLIC_SUPABASE_URL` | Sim (para listar/prover projetos reais) | URL do projeto Supabase. |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Sim (para listar/prover projetos reais) | Chave anônima utilizada pelo cliente/SSR do Supabase. |
+| `OPENROUTER_API_KEY` | Opcional | Necessária apenas para habilitar o widget de chat com IA (`/api/ai/chat`). Sem essa chave o widget permanece desativado no frontend. |
+
+> Caso `NEXT_PUBLIC_SUPABASE_URL` e `NEXT_PUBLIC_SUPABASE_ANON_KEY` não estejam configuradas, os endpoints de projetos (`/api/projects`) retornam erro 500 informando que o Supabase não está habilitado.
+
+## Instalação e scripts úteis
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+pnpm install          # instala dependências
+pnpm dev              # inicia o servidor de desenvolvimento em http://localhost:3000
+pnpm lint             # executa as regras de lint (recomendado antes de enviar alterações)
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## Fontes de dados
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+### Projetos
+- A listagem (`/projects`) e a página de detalhes (`/projects/[id]`) consomem os mesmos endpoints da API (`/api/projects` e `/api/projects/[id]`), garantindo consistência com o Supabase e compartilhando autenticação por cookies.
+- Quando os dados vêm do Supabase, campos como `created_at`, `updated_at`, `status` e participantes são exibidos automaticamente.
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+### Dashboard
+- Continua utilizando os mocks presentes em `src/lib/mockData.ts` para métricas e gráficos.
 
-## Learn More
+### Gamificação
+- Os mocks e tipagens (`UserGamificationProgress`, `InnovationTrail`, `TrailStage`) foram alinhados com o formato snake_case usado pelo Supabase, evitando divergências entre componentes e dados fictícios.
 
-To learn more about Next.js, take a look at the following resources:
+### Solicitações de solução (`/requests`)
+- O endpoint ainda mantém uma implementação em memória para fins de protótipo. Para persistência real recomenda-se:
+  1. Criar uma tabela (ex.: `innovation_solution_requests`) no Supabase com os campos `id`, `title`, `description`, `gerencia`, `created_at` e `created_by`.
+  2. Ajustar o handler `/api/requests` para gravar/consultar via Supabase usando a política de RLS apropriada.
+  3. Opcionalmente, exibir o histórico de solicitações no frontend com feedback otimista.
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+## Observações sobre o widget de IA
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+O componente `ChatWidget` agora verifica se `OPENROUTER_API_KEY` está configurada no servidor. Quando ausente, o botão permanece visível mas o formulário fica desativado e exibe uma mensagem guiando a configuração necessária, evitando erros no cliente.
 
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.

--- a/src/app/api/gamification/route.ts
+++ b/src/app/api/gamification/route.ts
@@ -40,21 +40,21 @@ export async function POST(request: Request) {
       }
 
       // Verifica se a etapa já foi completada
-      if (userProgressStore.completedStageIds.includes(stageId)) {
+      if (userProgressStore.completed_stage_ids.includes(stageId)) {
         return NextResponse.json({ message: "Etapa já completada anteriormente.", progress: userProgressStore }, { status: 200 });
       }
 
       // Atualiza o progresso
-      userProgressStore.completedStageIds.push(stageId);
-      userProgressStore.currentPoints += stage.pointsAwarded;
+      userProgressStore.completed_stage_ids.push(stageId);
+      userProgressStore.current_points += stage.points_awarded ?? 0;
 
-      if (stage.badgeIdToAward && !userProgressStore.earnedBadgeIds.includes(stage.badgeIdToAward)) {
-        const badgeExists = mockBadges.find(b => b.id === stage.badgeIdToAward);
+      if (stage.badge_id_to_award && !userProgressStore.earned_badge_ids.includes(stage.badge_id_to_award)) {
+        const badgeExists = mockBadges.find(b => b.id === stage.badge_id_to_award);
         if (badgeExists) {
-            userProgressStore.earnedBadgeIds.push(stage.badgeIdToAward);
+            userProgressStore.earned_badge_ids.push(stage.badge_id_to_award);
         }
       }
-      
+
       return NextResponse.json({ message: `Etapa "${stage.name}" completada!`, progress: userProgressStore });
     }
 

--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -5,10 +5,18 @@ import { cookies } from "next/headers";
 
 // Função para criar um cliente Supabase do lado do servidor (pode ser movida para um helper)
 function createSupabaseServerClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    console.error("Variáveis de ambiente do Supabase não configuradas.");
+    return null;
+  }
+
   const cookieStore = cookies();
   return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    supabaseUrl,
+    supabaseAnonKey,
     {
       cookies: {
         get(name: string) {
@@ -30,8 +38,11 @@ interface RouteParams {
 }
 
 // GET: Buscar um projeto específico por ID
-export async function GET(request: Request, { params }: RouteParams) {
+export async function GET(_request: Request, { params }: RouteParams) {
   const supabase = createSupabaseServerClient();
+  if (!supabase) {
+    return NextResponse.json({ error: "Supabase não configurado." }, { status: 500 });
+  }
   const projectId = params.id;
 
   try {
@@ -73,18 +84,19 @@ export async function GET(request: Request, { params }: RouteParams) {
 
     return NextResponse.json({ project });
 
-  } catch (err: any) {
+  } catch (err: unknown) {
     console.error(`Erro inesperado na API do projeto ${projectId} (GET):`, err);
-    return NextResponse.json(
-      { error: err.message || "Erro interno do servidor." },
-      { status: 500 }
-    );
+    const message = err instanceof Error ? err.message : "Erro interno do servidor.";
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }
 
 // PUT: Atualizar um projeto específico
 export async function PUT(request: Request, { params }: RouteParams) {
   const supabase = createSupabaseServerClient();
+  if (!supabase) {
+    return NextResponse.json({ error: "Supabase não configurado." }, { status: 500 });
+  }
   const projectId = params.id;
 
   try {
@@ -104,7 +116,7 @@ export async function PUT(request: Request, { params }: RouteParams) {
         return NextResponse.json({ error: "Nenhum dado fornecido para atualização." }, { status: 400 });
     }
 
-    const updateData: any = {};
+    const updateData: Partial<{ name: string; description: string; status: string; gerencia: string }> = {};
     if (name) updateData.name = name;
     if (description) updateData.description = description;
     if (status) updateData.status = status;
@@ -141,18 +153,19 @@ export async function PUT(request: Request, { params }: RouteParams) {
       );
     }
     return NextResponse.json({ project: updatedProject });
-  } catch (err: any) {
+  } catch (err: unknown) {
     console.error(`Erro inesperado na API do projeto ${projectId} (PUT):`, err);
-    return NextResponse.json(
-      { error: err.message || "Erro interno do servidor." },
-      { status: 500 }
-    );
+    const message = err instanceof Error ? err.message : "Erro interno do servidor.";
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }
 
 // DELETE: Excluir um projeto específico
 export async function DELETE(request: Request, { params }: RouteParams) {
   const supabase = createSupabaseServerClient();
+  if (!supabase) {
+    return NextResponse.json({ error: "Supabase não configurado." }, { status: 500 });
+  }
   const projectId = params.id;
 
   try {
@@ -183,11 +196,9 @@ export async function DELETE(request: Request, { params }: RouteParams) {
 
     return NextResponse.json({ message: "Projeto excluído com sucesso." }, { status: 200 }); // Ou 204 No Content
 
-  } catch (err: any) {
+  } catch (err: unknown) {
     console.error(`Erro inesperado na API do projeto ${projectId} (DELETE):`, err);
-    return NextResponse.json(
-      { error: err.message || "Erro interno do servidor." },
-      { status: 500 }
-    );
+    const message = err instanceof Error ? err.message : "Erro interno do servidor.";
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/src/app/gamification/trails/[id]/page.tsx
+++ b/src/app/gamification/trails/[id]/page.tsx
@@ -90,9 +90,9 @@ export default function TrailDetailPage() {
 
       <div className="bg-white !p-8 rounded-lg shadow-lg !mb-8">
         <div className="flex items-center !mb-4">
-          {trail.iconUrl && (
+          {trail.icon_url && (
             <div className="!mr-4 flex-shrink-0">
-              <Image src={trail.iconUrl} alt={`${trail.name} icon`} width={60} height={60} className="rounded-full" />
+              <Image src={trail.icon_url} alt={`${trail.name} icon`} width={60} height={60} className="rounded-full" />
             </div>
           )}
           <h2 className="text-3xl font-bold text-gray-800">{trail.name}</h2>
@@ -104,19 +104,19 @@ export default function TrailDetailPage() {
       {trail.stages.length > 0 ? (
         <div className="!space-y-4">
           {trail.stages.map((stage, index) => {
-            const isCompleted = userProgress?.completedStageIds.includes(stage.id);
-            const badgeToAward = stage.badgeIdToAward ? mockBadges.find(b => b.id === stage.badgeIdToAward) : null;
+            const isCompleted = userProgress?.completed_stage_ids.includes(stage.id);
+            const badgeToAward = stage.badge_id_to_award ? mockBadges.find(b => b.id === stage.badge_id_to_award) : null;
             return (
               <div key={stage.id} className={`!p-5 rounded-md border ${isCompleted ? "bg-green-50 border-green-300" : "bg-gray-50 border-gray-200"}`}>
                 <h4 className={`text-xl font-semibold ${isCompleted ? "text-green-700" : "text-gray-800"}`}>
                   Etapa {index + 1}: {stage.name} {isCompleted && "(Concluída)"}
                 </h4>
                 <p className="text-gray-600 !my-2">{stage.description}</p>
-                <p className="text-sm text-blue-500">Pontos: {stage.pointsAwarded}</p>
+                <p className="text-sm text-blue-500">Pontos: {stage.points_awarded ?? 0}</p>
                 {badgeToAward && (
                     <div className="!mt-3">
                         <p className="text-sm font-medium text-gray-700 !mb-1">Recompensa por completar esta etapa:</p>
-                        <BadgeCard badge={badgeToAward} earned={userProgress?.earnedBadgeIds.includes(badgeToAward.id) || false} />
+                        <BadgeCard badge={badgeToAward} earned={userProgress?.earned_badge_ids.includes(badgeToAward.id) || false} />
                     </div>
                 )}
                 {!isCompleted && (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,15 +17,17 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const isChatConfigured = Boolean(process.env.OPENROUTER_API_KEY);
+
   return (
     <html lang="pt-BR">
       <body className={inter.className}>
-        <Header /> {/* Adiciona o Header aqui */} 
+        <Header /> {/* Adiciona o Header aqui */}
         <main className="p-4 md:p-6">
-          {children} {/* Conteúdo da página será renderizado aqui */} 
+          {children} {/* Conteúdo da página será renderizado aqui */}
         </main>
         {/* Poderíamos adicionar um Footer aqui no futuro */}
-        <ChatWidget />
+        <ChatWidget isConfigured={isChatConfigured} />
       </body>
     </html>
   );

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -1,19 +1,28 @@
 // src/app/projects/[id]/page.tsx
 import React from 'react';
-import { getProjectById } from '@/lib/api';
-import { notFound } from 'next/navigation';
 import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { cookies, headers } from 'next/headers';
+import type { Project } from '@/lib/types';
 
-// Ajuste aqui: tipagem como Promise para evitar erro do build
 type ParamsPromise = Promise<{ id: string }>;
 
 export default async function ProjectDetailsPage({ params }: { params: ParamsPromise }) {
   const { id } = await params;
-  const project = await getProjectById(id);
+  const project = await fetchProject(id);
 
   if (!project) {
     notFound();
   }
+
+  const createdAt = formatDate(project.created_at);
+  const updatedAt = formatDate(project.updated_at);
+  const statusLabel = project.status ?? 'Sem status';
+  const gerencia = project.gerencia ?? 'Não informada';
+  const lastUpdatedBy = project.users?.full_name ?? null;
+  const participants = project.project_participants
+    ?.map((participant) => participant.users?.full_name ?? participant.user_id)
+    .filter(Boolean) ?? [];
 
   return (
     <div className="space-y-6 max-w-4xl !mx-5">
@@ -23,33 +32,31 @@ export default async function ProjectDetailsPage({ params }: { params: ParamsPro
 
       <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 !pb-4 border-b">
         <h2 className="text-3xl font-semibold flex-1 break-words">{project.name}</h2>
-        <span 
+        <span
           className={`text-sm font-medium !px-3 !py-1 rounded-full whitespace-nowrap ${getStatusBadgeColor(project.status)}`}
         >
-          Status: {project.status}
+          Status: {statusLabel}
         </span>
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 !gap-x-8 !gap-y-4">
-        <div>
-          <p className="text-sm font-medium text-gray-500">ID do Projeto</p>
-          <p className="text-lg text-gray-900">{project.id}</p>
-        </div>
-        <div>
-          <p className="text-sm font-medium text-gray-500">Gerência Responsável</p>
-          <p className="text-lg text-gray-900">{project.gerencia}</p>
-        </div>
-        <div>
-          <p className="text-sm font-medium text-gray-500">Data de Início</p>
-          <p className="text-lg text-gray-900">{project.startDate}</p>
-        </div>
-        {project.endDate && (
-          <div>
-            <p className="text-sm font-medium text-gray-500">Data de Conclusão</p>
-            <p className="text-lg text-gray-900">{project.endDate}</p>
-          </div>
-        )}
+        <DetailItem label="ID do Projeto" value={project.id} />
+        <DetailItem label="Gerência Responsável" value={gerencia} />
+        <DetailItem label="Criado em" value={createdAt} />
+        <DetailItem label="Última atualização" value={updatedAt} />
+        {lastUpdatedBy && <DetailItem label="Última modificação por" value={lastUpdatedBy} />}
       </div>
+
+      {participants.length > 0 && (
+        <div className="!pt-4 border-t">
+          <h3 className="text-xl font-semibold !mb-2">Participantes</h3>
+          <ul className="list-disc list-inside text-gray-700 space-y-1">
+            {participants.map((participant) => (
+              <li key={participant}>{participant}</li>
+            ))}
+          </ul>
+        </div>
+      )}
 
       {project.description && (
         <div className="!pt-4 border-t">
@@ -61,13 +68,82 @@ export default async function ProjectDetailsPage({ params }: { params: ParamsPro
   );
 }
 
-// Função auxiliar fora do export
-function getStatusBadgeColor(status: string) {
-  switch (status) {
-    case 'Completed': return 'bg-green-100 text-green-800';
-    case 'Development': return 'bg-blue-100 text-blue-800';
-    case 'On Hold': return 'bg-yellow-100 text-yellow-800';
-    case 'Idea': return 'bg-purple-100 text-purple-800';
-    default: return 'bg-gray-100 text-gray-800';
+async function fetchProject(id: string): Promise<Project | null> {
+  const headersList = headers();
+  const host = headersList.get('host');
+  const protocol = headersList.get('x-forwarded-proto') ?? (process.env.NODE_ENV === 'production' ? 'https' : 'http');
+
+  if (!host) {
+    console.error('Cabeçalho Host ausente ao buscar projeto.');
+    return null;
   }
+
+  const cookieStore = cookies();
+  const cookieHeader = cookieStore
+    .getAll()
+    .map(({ name, value }) => `${name}=${value}`)
+    .join('; ');
+
+  const response = await fetch(`${protocol}://${host}/api/projects/${id}`, {
+    headers: {
+      ...(cookieHeader ? { Cookie: cookieHeader } : {}),
+    },
+    cache: 'no-store',
+  });
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (response.status === 401) {
+    throw new Error('Usuário não autenticado para visualizar projetos.');
+  }
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(`Falha ao carregar projeto (${response.status}): ${errorBody}`);
+  }
+
+  const data = (await response.json()) as { project?: Project | null };
+  return data.project ?? null;
+}
+
+function formatDate(value?: string | null) {
+  if (!value) {
+    return 'Não informado';
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return 'Data inválida';
+  }
+
+  return new Intl.DateTimeFormat('pt-BR', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(parsed);
+}
+
+function getStatusBadgeColor(status?: string | null) {
+  switch (status) {
+    case 'Completed':
+      return 'bg-green-100 text-green-800';
+    case 'Development':
+      return 'bg-blue-100 text-blue-800';
+    case 'On Hold':
+      return 'bg-yellow-100 text-yellow-800';
+    case 'Idea':
+      return 'bg-purple-100 text-purple-800';
+    default:
+      return 'bg-gray-100 text-gray-800';
+  }
+}
+
+function DetailItem({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="text-sm font-medium text-gray-500">{label}</p>
+      <p className="text-lg text-gray-900">{value}</p>
+    </div>
+  );
 }

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -30,9 +30,10 @@ export default function ProjectsPage() {
         }
         const data = await response.json();
         setAllProjects(data.projects || []);
-      } catch (err: any) {
+      } catch (err: unknown) {
         console.error("Erro ao buscar projetos:", err);
-        setError(err.message || "Ocorreu um erro ao carregar os projetos.");
+        const message = err instanceof Error ? err.message : "Ocorreu um erro ao carregar os projetos.";
+        setError(message);
         setAllProjects([]); // Limpa os projetos em caso de erro
       }
       setIsLoading(false);

--- a/src/components/ai/ChatWidget.tsx
+++ b/src/components/ai/ChatWidget.tsx
@@ -1,15 +1,27 @@
 'use client'
 
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { MessageCircle } from 'lucide-react'
 
-export default function ChatWidget() {
+interface ChatWidgetProps {
+  isConfigured: boolean;
+}
+
+export default function ChatWidget({ isConfigured }: ChatWidgetProps) {
   const [isOpen, setIsOpen] = useState(false)
   const [messages, setMessages] = useState<{ role: string; content: string }[]>([])
   const [userInput, setUserInput] = useState('')
 
+  const unavailableMessage = useMemo(
+    () => 'Assistente indisponível. Configure a variável OPENROUTER_API_KEY para ativar o chat.',
+    []
+  )
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
+    if (!isConfigured) {
+      return
+    }
     if (!userInput.trim()) return
 
     // adiciona mensagem do usuário
@@ -114,6 +126,11 @@ export default function ChatWidget() {
 
         {/* Área de mensagens */}
         <div className="flex-1 overflow-y-auto !px-4 !py-2 space-y-2 bg-white">
+          {!isConfigured && (
+            <div className="text-xs text-orange-700 bg-orange-50 border border-orange-200 rounded-md !px-3 !py-2">
+              {unavailableMessage}
+            </div>
+          )}
           {messages.map((msg, i) => (
             <div
               key={i}
@@ -136,15 +153,17 @@ export default function ChatWidget() {
           <input
             className="flex-1 border border-gray-300 rounded-full !px-4 !py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
             type="text"
-            placeholder="Digite uma mensagem..."
+            placeholder={isConfigured ? 'Digite uma mensagem...' : 'Chat indisponível no momento'}
             value={userInput}
             onChange={(e) => setUserInput(e.target.value)}
+            disabled={!isConfigured}
           />
           <button
             type="submit"
-            className="shrink-0 bg-blue-600 text-white !px-4 !py-1.5 rounded-full hover:bg-blue-700 text-sm transition"
+            className="shrink-0 bg-blue-600 text-white !px-4 !py-1.5 rounded-full hover:bg-blue-700 text-sm transition disabled:opacity-50 disabled:cursor-not-allowed"
+            disabled={!isConfigured}
           >
-            Enviar
+            {isConfigured ? 'Enviar' : 'Indisponível'}
           </button>
         </form>
       </div>

--- a/src/components/gamification/UserProfileGamification.tsx
+++ b/src/components/gamification/UserProfileGamification.tsx
@@ -1,22 +1,35 @@
 // src/components/gamification/UserProfileGamification.tsx
 import React from 'react';
-import { UserGamificationProgress, Badge, User } from '@/lib/types';
+import { UserGamificationProgress, Badge, UserProfile } from '@/lib/types';
 // import { mockBadges, mockUser } from '@/lib/mockData'; // Removido pois não está sendo usado diretamente aqui
 import BadgeCard from './BadgeCard';
 
 interface UserProfileGamificationProps {
   progress: UserGamificationProgress;
-  user: User;
+  user: UserProfile;
   allBadges: Badge[]; // Pass all available badges to find details
 }
 
 const UserProfileGamification: React.FC<UserProfileGamificationProps> = ({ progress, user, allBadges }) => {
-  const earnedBadgesDetails = allBadges.filter(badge => progress.earnedBadgeIds.includes(badge.id));
+  const earnedBadgeIds = progress.earned_badge_ids ?? [];
+  const completedStageIds = progress.completed_stage_ids ?? [];
+
+  const earnedBadgesDetails = allBadges.filter((badge) => earnedBadgeIds.includes(badge.id));
+
+  const userName = user.full_name ?? 'Colaborador';
 
   return (
     <div className="!p-6 bg-white rounded-lg border border-gray-200 shadow-md">
-      <h3 className="text-2xl font-semibold text-gray-800 !mb-2">Progresso de {user.name}</h3>
-      <p className="text-lg text-blue-600 font-bold !mb-4">Pontos Atuais: {progress.current_points}</p>
+      <h3 className="text-2xl font-semibold text-gray-800 !mb-2">Progresso de {userName}</h3>
+      {user.job_title && (
+        <p className="text-sm text-gray-500 !mb-2">{user.job_title}</p>
+      )}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between !gap-2 !mb-4">
+        <p className="text-lg text-blue-600 font-bold">Pontos atuais: {progress.current_points}</p>
+        <p className="text-sm text-gray-600">
+          Etapas concluídas: {completedStageIds.length}
+        </p>
+      </div>
 
       <h4 className="text-xl font-semibold text-gray-700 !mt-6 !mb-3">Badges Conquistados:</h4>
       {earnedBadgesDetails.length > 0 ? (

--- a/src/components/projects/ProjectCard.tsx
+++ b/src/components/projects/ProjectCard.tsx
@@ -18,22 +18,44 @@ const getStatusBadgeColor = (status: Project['status']) => {
   }
 };
 
+const formatDate = (date?: string | null) => {
+  if (!date) {
+    return "Não informado";
+  }
+
+  const parsedDate = new Date(date);
+  if (Number.isNaN(parsedDate.getTime())) {
+    return "Data inválida";
+  }
+
+  return new Intl.DateTimeFormat("pt-BR", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  }).format(parsedDate);
+};
+
 const ProjectCard: React.FC<ProjectCardProps> = ({ project }) => {
+  const createdAtLabel = formatDate(project.created_at);
+  const updatedAtLabel = project.updated_at ? formatDate(project.updated_at) : null;
+  const gerencia = project.gerencia ?? "Não informada";
+  const statusLabel = project.status ?? "Sem status";
+
   return (
     <Link href={`/projects/${project.id}`} className="!p-3 block card hover:border-blue-500 border border-transparent transition-colors duration-200">
       {/* Usando Link para tornar o card clicável e navegar para os detalhes */}
       <div className="flex justify-between items-start !mb-2">
         <h3 className="text-lg font-semibold truncate" title={project.name}>{project.name}</h3>
-        <span 
+        <span
           className={`text-xs font-medium !px-2.5 !py-0.5 rounded-full ${getStatusBadgeColor(project.status)}`}
         >
-          {project.status}
+          {statusLabel}
         </span>
       </div>
-      <p className="text-sm text-gray-600 !mb-2">Gerência: {project.gerencia}</p>
-      <p className="text-sm text-gray-500">Início: {project.startDate}</p>
-      {project.endDate && (
-         <p className="text-sm text-gray-500">Fim: {project.endDate}</p>
+      <p className="text-sm text-gray-600 !mb-2">Gerência: {gerencia}</p>
+      <p className="text-sm text-gray-500">Criado em: {createdAtLabel}</p>
+      {updatedAtLabel && (
+        <p className="text-sm text-gray-500">Atualizado em: {updatedAtLabel}</p>
       )}
       {/* Poderíamos adicionar uma breve descrição aqui se disponível */}
       {/* {project.description && <p className="text-sm text-gray-700 mt-2 line-clamp-2">{project.description}</p>} */}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -15,14 +15,8 @@ export async function getAllProjects(): Promise<Project[]> {
   return mockProjects;
 }
 
-// Simula a busca de um projeto por ID
-export async function getProjectById(id: string): Promise<Project | undefined> {
-  await new Promise(resolve => setTimeout(resolve, 80)); 
-  return mockProjects.find(p => p.id === id);
-}
-
 // Simula a busca do resumo de projetos para gráficos
 export async function getProjectsSummary(): Promise<typeof mockProjectsSummary> {
-  await new Promise(resolve => setTimeout(resolve, 60)); 
+  await new Promise(resolve => setTimeout(resolve, 60));
   return mockProjectsSummary;
 }

--- a/src/lib/mockData.ts
+++ b/src/lib/mockData.ts
@@ -1,5 +1,5 @@
 // src/lib/mockData.ts
-import { Project, DashboardMetric } from "./types";
+import { Project, DashboardMetric, Badge, InnovationTrail, UserGamificationProgress, UserProfile, UserCompletedStage } from "./types";
 
 // Dados mockados para Projetos
 export const mockProjects: Project[] = [
@@ -36,9 +36,6 @@ export const mockProjectsSummary = {
   ]
 };
 
-// Dados Mockados para Gamificação
-import { Badge, InnovationTrail, UserGamificationProgress, UserProfile, UserCompletedStage } from "./types";
-
 export const mockBadges: Badge[] = [
   { id: "B001", name: "Inovador Iniciante", description: "Completou sua primeira trilha de inovação.", image_url: "/icons/badge_beginner.svg" },
   { id: "B002", name: "Mestre das Ideias", description: "Submeteu 5 ideias de alta qualidade.", image_url: "/icons/badge_idea_master.svg" },
@@ -54,19 +51,33 @@ export const mockInnovationTrails: InnovationTrail[] = [
     icon_url: "/icons/trail_sustainability.svg",
     stages: [
       {
-        id: "T001S001", name: "Introdução à Sustentabilidade", description: "Leia o material sobre os pilares da sustentabilidade.", criteria_type: "read_sustainability_intro_material", points_awarded: 10,
-        trail_id: "",
-        stage_sequence: 0
+        id: "T001S001",
+        trail_id: "T001",
+        name: "Introdução à Sustentabilidade",
+        description: "Leia o material sobre os pilares da sustentabilidade.",
+        criteria_type: "read_sustainability_intro_material",
+        points_awarded: 10,
+        stage_sequence: 1,
       },
       {
-        id: "T001S002", name: "Ideia Sustentável", description: "Submeta uma ideia de projeto com foco em sustentabilidade.", criteria_type: "submit_idea_sustainability_topic", points_awarded: 50, badge_to_award: mockBadges[3],
-        trail_id: "",
-        stage_sequence: 0
+        id: "T001S002",
+        trail_id: "T001",
+        name: "Ideia Sustentável",
+        description: "Submeta uma ideia de projeto com foco em sustentabilidade.",
+        criteria_type: "submit_idea_sustainability_topic",
+        points_awarded: 50,
+        badge_id_to_award: mockBadges[3].id,
+        badge_to_award: mockBadges[3],
+        stage_sequence: 2,
       },
       {
-        id: "T001S003", name: "Feedback Construtivo", description: "Comente em pelo menos duas outras ideias da trilha de sustentabilidade.", criteria_type: "comment_on_2_sustainability_ideas", points_awarded: 20,
-        trail_id: "",
-        stage_sequence: 0
+        id: "T001S003",
+        trail_id: "T001",
+        name: "Feedback Construtivo",
+        description: "Comente em pelo menos duas outras ideias da trilha de sustentabilidade.",
+        criteria_type: "comment_on_2_sustainability_ideas",
+        points_awarded: 20,
+        stage_sequence: 3,
       },
     ]
   },
@@ -77,14 +88,22 @@ export const mockInnovationTrails: InnovationTrail[] = [
     icon_url: "/icons/trail_optimization.svg",
     stages: [
       {
-        id: "T002S001", name: "Mapeamento de Processo Atual", description: "Analise um processo existente e identifique gargalos.", criteria_type: "analyze_current_process_bottlenecks", points_awarded: 30,
-        trail_id: "",
-        stage_sequence: 0
+        id: "T002S001",
+        trail_id: "T002",
+        name: "Mapeamento de Processo Atual",
+        description: "Analise um processo existente e identifique gargalos.",
+        criteria_type: "analyze_current_process_bottlenecks",
+        points_awarded: 30,
+        stage_sequence: 1,
       },
       {
-        id: "T002S002", name: "Proposta de Melhoria", description: "Submeta uma ideia para otimizar o processo analisado.", criteria_type: "submit_idea_process_optimization", points_awarded: 50,
-        trail_id: "",
-        stage_sequence: 0
+        id: "T002S002",
+        trail_id: "T002",
+        name: "Proposta de Melhoria",
+        description: "Submeta uma ideia para otimizar o processo analisado.",
+        criteria_type: "submit_idea_process_optimization",
+        points_awarded: 50,
+        stage_sequence: 2,
       },
     ]
   }
@@ -93,16 +112,19 @@ export const mockInnovationTrails: InnovationTrail[] = [
 export const mockUser: UserProfile = {
   id: "U001",
   full_name: "Usuário Teste",
+  job_title: "Inovador",
 };
 
 export const mockUserCompletedStage: UserCompletedStage = {
   user_id: "U001",
-  stage_id: "T001S001"
-}
+  stage_id: "T001S001",
+  completed_at: "2024-04-01T12:00:00Z",
+};
 export const mockUserGamificationProgress: UserGamificationProgress = {
   user_id: "U001",
   current_points: 60,
-  earnedBadgeIds: ["B001"],
+  earned_badge_ids: ["B001"],
+  completed_stage_ids: ["T001S001"],
   user_completed_stages: [mockUserCompletedStage],
 };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -26,8 +26,16 @@ export interface Project {
     full_name?: string | null;
     avatar_url?: string | null;
   } | null;
+  project_participants?: {
+    user_id: string;
+    users?: {
+      full_name?: string | null;
+      avatar_url?: string | null;
+      job_title?: string | null;
+    } | null;
+  }[] | null;
   // Se precisarmos de participantes diretamente no objeto Project, seria uma lista de UserProfile ou de IDs.
-  // project_participants?: ProjectParticipant[]; 
+  // project_participants?: ProjectParticipant[];
 }
 
 // Representa a associação de um usuário a um projeto
@@ -59,7 +67,7 @@ export interface TrailStage {
   points_awarded?: number;
   badge_id_to_award?: string | null; // UUID do badge concedido
   criteria_type?: string | null; // Tipo de critério para completar (ex: "submit_task", "receive_approval")
-  criteria_details?: any | null; // JSONB com detalhes do critério
+  criteria_details?: Record<string, unknown> | null; // JSONB com detalhes do critério
   badge_to_award?: Badge | null; // Opcional, para dados do badge
 }
 
@@ -76,10 +84,11 @@ export interface InnovationTrail {
 
 // Progresso de gamificação de um usuário (geral)
 export interface UserGamificationProgress {
-  earnedBadgeIds: any;
   user_id: string; // UUID, chave primária e estrangeira para users.id
   current_points: number;
   updated_at?: string;
+  earned_badge_ids: string[];
+  completed_stage_ids: string[];
   // Badges e estágios completados seriam buscados de suas respectivas tabelas
   // user_earned_badges?: UserEarnedBadge[];
   user_completed_stages?: UserCompletedStage[];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -19,8 +23,18 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- adjust project cards and details to use Supabase field names, fetch the `/api/projects/[id]` endpoint, and show participants/metadata
- normalize gamification mocks and components to the snake_case schema used by Supabase
- guard AI chat and project APIs when environment variables are missing and document the required configuration

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d4309ef31c8332aa243bf36313863a